### PR TITLE
Support SSH GitHub URLs in package resolution

### DIFF
--- a/Sources/LicenseCLI/LicenseCLI.swift
+++ b/Sources/LicenseCLI/LicenseCLI.swift
@@ -6,10 +6,10 @@ struct LicenseCLI: AsyncParsableCommand {
     @Argument(help: "Directories where Package.swift is located", completion: .directory)
     var projectDirectory: [String] = []
 
-    @Option(name: .long, parsing: .upToNextOption, help: "GitHub repository URLs (e.g., https://github.com/owner/repo)")
+    @Option(name: .long, parsing: .upToNextOption, help: "GitHub repository URLs (e.g., https://github.com/owner/repo or git@github.com:owner/repo.git)")
     var githubRepo: [String] = []
 
-    @Option(name: .long, parsing: .upToNextOption, help: "GitHub repository URLs with dependencies (e.g., https://github.com/owner/repo@1.0.0)")
+    @Option(name: .long, parsing: .upToNextOption, help: "GitHub repository URLs with dependencies (e.g., https://github.com/owner/repo@1.0.0 or git@github.com:owner/repo.git@1.0.0)")
     var packageDeps: [String] = []
 
     @Option(name: .long, help: "Cache directory for package dependencies clones (reuses existing clones if revision matches)", completion: .directory)

--- a/Sources/LicenseCLICore/Dependencies.swift
+++ b/Sources/LicenseCLICore/Dependencies.swift
@@ -13,34 +13,23 @@ struct Dependencies: Decodable, Equatable {
         }
 
         var licenseURL: URL? {
-            URL(string: location.rawGithubContentURL())?
-                .appendingPathComponent(state.revision)
-                .appendingPathComponent("LICENSE")
+            repo?.licenseURL(for: state.revision)
         }
 
         var licenseTxtURL: URL? {
-            URL(string: location.rawGithubContentURL())?
-                .appendingPathComponent(state.revision)
-                .appendingPathComponent("LICENSE.txt")
+            repo?.licenseTxtURL(for: state.revision)
         }
 
         var licenseCapitalTxtURL: URL? {
-            URL(string: location.rawGithubContentURL())?
-                .appendingPathComponent(state.revision)
-                .appendingPathComponent("License.txt")
+            repo?.licenseCapitalTxtURL(for: state.revision)
         }
 
         var name: String {
-            URL(string: location.rawGithubContentURL())?.lastPathComponent ?? identity
+            repo?.name ?? identity
         }
-    }
-}
 
-private extension String {
-    func rawGithubContentURL() -> String {
-        replacingOccurrences(of: ".git", with: "").replacingOccurrences(
-            of: "github.com",
-            with: "raw.githubusercontent.com"
-        )
+        private var repo: GitHubRepo? {
+            GitHubRepo(urlString: location)
+        }
     }
 }

--- a/Sources/LicenseCLICore/GitHubRepo.swift
+++ b/Sources/LicenseCLICore/GitHubRepo.swift
@@ -65,7 +65,7 @@ struct GitHubRepo {
             return nil
         }
 
-        return parsePath(String(url.path.drop(while: { $0 == "/" })))
+        return parsePath(String(url.path.drop { $0 == "/" }))
     }
 
     private static func parsePath(_ path: String) -> ParsedLocation? {
@@ -115,11 +115,10 @@ struct GitHubRepo {
             return nil
         }
 
-        let normalizedPart: Substring
-        if repositoryPart.hasSuffix(".git") {
-            normalizedPart = repositoryPart.dropLast(4)
+        let normalizedPart: Substring = if repositoryPart.hasSuffix(".git") {
+            repositoryPart.dropLast(4)
         } else {
-            normalizedPart = repositoryPart
+            repositoryPart
         }
 
         guard !normalizedPart.isEmpty else {

--- a/Sources/LicenseCLICore/GitHubRepo.swift
+++ b/Sources/LicenseCLICore/GitHubRepo.swift
@@ -1,8 +1,19 @@
 import Foundation
 
 struct GitHubRepo {
+    struct ParsedLocation {
+        let owner: String
+        let name: String
+        let version: String?
+    }
+
     let owner: String
     let name: String
+
+    init(owner: String, name: String) {
+        self.owner = owner
+        self.name = name
+    }
 
     var identity: String {
         "\(owner)/\(name)".lowercased()
@@ -33,11 +44,109 @@ struct GitHubRepo {
     }
 
     init?(urlString: String) {
-        guard let url = URL(string: urlString) else { return nil }
-        let pathComponents = url.pathComponents.filter { $0 != "/" }
-        guard pathComponents.count >= 2 else { return nil }
+        guard let parsed = Self.parse(urlString: urlString), parsed.version == nil else {
+            return nil
+        }
 
-        owner = pathComponents[0]
-        name = pathComponents[1].replacingOccurrences(of: ".git", with: "")
+        self.init(owner: parsed.owner, name: parsed.name)
+    }
+
+    static func parse(urlString: String) -> ParsedLocation? {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let scpStylePath = trimmed.scpStyleGitHubPath {
+            return parsePath(scpStylePath)
+        }
+
+        guard let url = URL(string: trimmed),
+              let host = url.host?.lowercased(),
+              host == "github.com" || host == "www.github.com"
+        else {
+            return nil
+        }
+
+        return parsePath(String(url.path.drop(while: { $0 == "/" })))
+    }
+
+    private static func parsePath(_ path: String) -> ParsedLocation? {
+        guard let (ownerPart, referencePart) = path[...].splitOnce(separator: "/"),
+              !ownerPart.isEmpty,
+              let parsedReference = parseReference(referencePart)
+        else {
+            return nil
+        }
+
+        return ParsedLocation(
+            owner: String(ownerPart),
+            name: parsedReference.name,
+            version: parsedReference.version
+        )
+    }
+
+    private static func parseReference(_ reference: Substring) -> (name: String, version: String?)? {
+        let repositoryPart: Substring
+        let versionPart: Substring?
+
+        if let (repository, version) = reference.splitOnce(separator: "@") {
+            repositoryPart = repository
+            versionPart = version
+        } else {
+            repositoryPart = reference
+            versionPart = nil
+        }
+
+        guard let name = normalizedRepositoryName(from: repositoryPart) else {
+            return nil
+        }
+
+        guard let versionPart else {
+            return (name, nil)
+        }
+
+        guard !versionPart.isEmpty else {
+            return nil
+        }
+
+        return (name, String(versionPart))
+    }
+
+    private static func normalizedRepositoryName(from repositoryPart: Substring) -> String? {
+        guard !repositoryPart.isEmpty else {
+            return nil
+        }
+
+        let normalizedPart: Substring
+        if repositoryPart.hasSuffix(".git") {
+            normalizedPart = repositoryPart.dropLast(4)
+        } else {
+            normalizedPart = repositoryPart
+        }
+
+        guard !normalizedPart.isEmpty else {
+            return nil
+        }
+
+        return String(normalizedPart)
+    }
+}
+
+private extension String {
+    var scpStyleGitHubPath: String? {
+        let prefix = "git@github.com:"
+        guard hasPrefix(prefix) else { return nil }
+        return String(dropFirst(prefix.count))
+    }
+}
+
+private extension Substring {
+    func splitOnce(separator: Character) -> (Substring, Substring)? {
+        guard let separatorIndex = firstIndex(of: separator) else {
+            return nil
+        }
+
+        let head = self[..<separatorIndex]
+        let tailStart = index(after: separatorIndex)
+        let tail = self[tailStart...]
+        return (head, tail)
     }
 }

--- a/Sources/LicenseCLICore/GitHubRepoWithVersion.swift
+++ b/Sources/LicenseCLICore/GitHubRepoWithVersion.swift
@@ -27,23 +27,14 @@ struct GitHubRepoWithVersion {
     /// - https://github.com/owner/repo@1.2.3
     /// - https://github.com/owner/repo@abc123
     init?(urlString: String) {
-        // Split by @ to separate URL and version
-        let components = urlString.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false)
-        let repoURLString = String(components[0])
-
-        // Parse the base GitHub repo
-        guard let repo = GitHubRepo(urlString: repoURLString) else {
+        guard let parsed = GitHubRepo.parse(urlString: urlString) else {
             return nil
         }
-        self.repo = repo
+
+        self.repo = GitHubRepo(owner: parsed.owner, name: parsed.name)
 
         // Parse version specification if present
-        if components.count > 1 {
-            let versionString = String(components[1])
-            if versionString.isEmpty {
-                return nil // Invalid: URL ends with @
-            }
-
+        if let versionString = parsed.version {
             // Heuristic: if it looks like a semantic version tag, treat as tag
             // Otherwise, could be branch name or revision
             // For simplicity, we'll treat everything as a git reference

--- a/Sources/LicenseCLICore/GitHubRepoWithVersion.swift
+++ b/Sources/LicenseCLICore/GitHubRepoWithVersion.swift
@@ -31,7 +31,7 @@ struct GitHubRepoWithVersion {
             return nil
         }
 
-        self.repo = GitHubRepo(owner: parsed.owner, name: parsed.name)
+        repo = GitHubRepo(owner: parsed.owner, name: parsed.name)
 
         // Parse version specification if present
         if let versionString = parsed.version {

--- a/Sources/LicenseCLICore/SwiftPackageValidator.swift
+++ b/Sources/LicenseCLICore/SwiftPackageValidator.swift
@@ -127,9 +127,9 @@ public enum SwiftPackageValidatorError: LocalizedError {
             "name option cannot be empty"
         case .noInputProvided:
             "At least one package directory, GitHub repository URL, or package dependency URL must be provided"
-        case .invalidGitHubURL(let url):
+        case let .invalidGitHubURL(url):
             "Invalid GitHub URL: \(url). URL must be in format https://github.com/owner/repo[@version] or git@github.com:owner/repo.git[@version]"
-        case .invalidPackageDepsURL(let url):
+        case let .invalidPackageDepsURL(url):
             "Invalid package dependency URL: \(url). URL must be in format https://github.com/owner/repo[@version] or git@github.com:owner/repo.git[@version]"
         case .gitNotAvailable:
             "git command is not available. Please install git to use --package-deps option"

--- a/Sources/LicenseCLICore/SwiftPackageValidator.swift
+++ b/Sources/LicenseCLICore/SwiftPackageValidator.swift
@@ -39,7 +39,6 @@ public struct SwiftPackageValidator {
             try validatePackageDepsURL(packageDepsURL)
         }
 
-        // Validate git is available if package-deps is used
         if !packageDependenciesURLs.isEmpty {
             try validateGitAvailability()
         }
@@ -48,17 +47,8 @@ public struct SwiftPackageValidator {
     }
 
     private func validateGitHubURL(_ urlString: String) throws {
-        guard let url = URL(string: urlString),
-              let host = url.host,
-              host == "github.com" || host == "www.github.com"
-        else {
+        guard GitHubRepo.parse(urlString: urlString) != nil else {
             logger.error("Invalid GitHub URL: \(urlString)")
-            throw SwiftPackageValidatorError.invalidGitHubURL(urlString)
-        }
-
-        let pathComponents = url.pathComponents.filter { $0 != "/" }
-        guard pathComponents.count >= 2 else {
-            logger.error("GitHub URL must contain owner and repository: \(urlString)")
             throw SwiftPackageValidatorError.invalidGitHubURL(urlString)
         }
 
@@ -66,7 +56,6 @@ public struct SwiftPackageValidator {
     }
 
     private func validatePackageDepsURL(_ urlString: String) throws {
-        // Parse the URL to validate it can be parsed as GitHubRepoWithVersion
         guard GitHubRepoWithVersion(urlString: urlString) != nil else {
             logger.error("Invalid package dependency URL: \(urlString)")
             throw SwiftPackageValidatorError.invalidPackageDepsURL(urlString)
@@ -138,10 +127,10 @@ public enum SwiftPackageValidatorError: LocalizedError {
             "name option cannot be empty"
         case .noInputProvided:
             "At least one package directory, GitHub repository URL, or package dependency URL must be provided"
-        case let .invalidGitHubURL(url):
-            "Invalid GitHub URL: \(url). URL must be in format https://github.com/owner/repo"
-        case let .invalidPackageDepsURL(url):
-            "Invalid package dependency URL: \(url). URL must be in format https://github.com/owner/repo[@version]"
+        case .invalidGitHubURL(let url):
+            "Invalid GitHub URL: \(url). URL must be in format https://github.com/owner/repo[@version] or git@github.com:owner/repo.git[@version]"
+        case .invalidPackageDepsURL(let url):
+            "Invalid package dependency URL: \(url). URL must be in format https://github.com/owner/repo[@version] or git@github.com:owner/repo.git[@version]"
         case .gitNotAvailable:
             "git command is not available. Please install git to use --package-deps option"
         }

--- a/Tests/LicenseCLITests/GitHubRepoParsingTests.swift
+++ b/Tests/LicenseCLITests/GitHubRepoParsingTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+@testable import LicenseCLICore
+import Testing
+
+@Suite
+struct GitHubRepoParsingTests {
+    @Test
+    func parsesSCPStyleGitHubURL() {
+        let repo = GitHubRepo(urlString: "git@github.com:apple/swift-collections.git")
+
+        #expect(repo?.owner == "apple")
+        #expect(repo?.name == "swift-collections")
+    }
+
+    @Test
+    func parsesSCPStyleGitHubURLWithVersion() {
+        let repo = GitHubRepoWithVersion(urlString: "git@github.com:apple/swift-collections.git@1.1.0")
+
+        #expect(repo?.repo.owner == "apple")
+        #expect(repo?.repo.name == "swift-collections")
+        #expect(repo?.version == .tag("1.1.0"))
+    }
+
+    @Test
+    func buildsLicenseURLFromSCPStylePackageResolvedPin() throws {
+        let data = Data(
+            """
+            {
+              "pins": [
+                {
+                  "identity": "mappathkit",
+                  "location": "git@github.com:apple/swift-collections.git",
+                  "state": {
+                    "revision": "abc123"
+                  }
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let dependencies = try JSONDecoder().decode(Dependencies.self, from: data)
+
+        #expect(
+            dependencies.pins.first?.licenseURL?.absoluteString
+                == "https://raw.githubusercontent.com/apple/swift-collections/abc123/LICENSE"
+        )
+        #expect(dependencies.pins.first?.name == "swift-collections")
+    }
+}


### PR DESCRIPTION
## Summary
- support SCP-style GitHub URLs like `git@github.com:owner/repo.git` when parsing package locations and `--package-deps` inputs
- reuse the shared GitHub URL parser for dependency license URL generation and validation so SSH and HTTPS inputs behave consistently
- update the integration test expectation to compare unique displayed dependency names against the current dependency graph

## Verification
- swift test