### PR TITLE
Update gitnagg to 0.2.0

### DIFF
--- a/.gitnagg.yml
+++ b/.gitnagg.yml
@@ -12,7 +12,7 @@ rules:
           gte: 80
         - metric: files
           gte: 8
-  - severity: error
+  - severity: warning
     message: Commit now. Keep the next LicenseCLI step in a fresh commit.
     when:
       or:

--- a/.gitnagg.yml
+++ b/.gitnagg.yml
@@ -2,13 +2,23 @@ version: 1
 resolution: first-match
 
 rules:
-  - severity: warning
-    message: This diff is spreading out. Make a checkpoint commit soon.
+  - severity: error
+    message: Stop. This LicenseCLI diff is already too large for one commit. Split it before continuing.
     when:
       or:
         - metric: added
-          gte: 150
+          gte: 140
         - metric: deleted
-          gte: 200
+          gte: 80
         - metric: files
-          gte: 5
+          gte: 8
+  - severity: error
+    message: Commit now. Keep the next LicenseCLI step in a fresh commit.
+    when:
+      or:
+        - metric: added
+          gte: 60
+        - metric: deleted
+          gte: 30
+        - metric: files
+          gte: 4

--- a/.gitnagg.yml
+++ b/.gitnagg.yml
@@ -1,3 +1,14 @@
-added: 150
-deleted: 200
-files: 5
+version: 1
+resolution: first-match
+
+rules:
+  - severity: warning
+    message: This diff is spreading out. Make a checkpoint commit soon.
+    when:
+      or:
+        - metric: added
+          gte: 150
+        - metric: deleted
+          gte: 200
+        - metric: files
+          gte: 5

--- a/nestfile.yaml
+++ b/nestfile.yaml
@@ -9,6 +9,6 @@ targets:
     assetName: SwiftLintBinary.artifactbundle.zip
     checksum: 12befab676fc972ffde2ec295d016d53c3a85f64aabd9c7fee0032d681e307e9
   - reference: Ryu0118/gitnagg
-    version: 0.1.0
-    assetName: gitnagg-0.1.0.artifactbundle.zip
-    checksum: e2ae97f2a4670cce30ce70659890430eb3c3966f0b058775fe2c6cab1816fa5e
+    version: 0.2.0
+    assetName: gitnagg-0.2.0.artifactbundle.zip
+    checksum: a6525e3df2aece1fbadf2ebf556fb81154f9e5a1bc221ca176ba72884bffa47a


### PR DESCRIPTION
## Summary
- update gitnagg in nestfile to 0.2.0 and refresh the artifact checksum
- migrate .gitnagg.yml to the new rule-based config format introduced in 0.2.0

## Verification
- make install-commands
- .nest/bin/gitnagg check
- make check