### PR TITLE
Use a global, project-shared package cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SUBCOMMANDS:
 
 ### `generate` (default)
 ```
-USAGE: licensecli generate [<project-directory> ...] [--github-repo <github-repo> ...] [--package-deps <package-deps> ...] --output-directory <output-directory> [--name <name>] [--verbose]
+USAGE: licensecli generate [<project-directory> ...] [--github-repo <github-repo> ...] [--package-deps <package-deps> ...] [--package-deps-cache-dir <package-deps-cache-dir>] [--no-cache] --output-directory <output-directory> [--name <name>] [--verbose]
 
 ARGUMENTS:
   <project-directory>     Directories where Package.swift is located
@@ -35,6 +35,9 @@ OPTIONS:
                           GitHub repository URLs (e.g., https://github.com/owner/repo)
   --package-deps <package-deps>
                           GitHub repository URLs with dependencies (e.g., https://github.com/owner/repo@1.0.0)
+  --package-deps-cache-dir <package-deps-cache-dir>
+                          Use this directory to cache package dependency clones instead of the global cache (no automatic pruning)
+  --no-cache              Disable caching; clone package dependencies into a temporary directory discarded after the run
   -o, --output-directory <output-directory>
                           Output directory
   -n, --name <name>       (default: Licenses)
@@ -46,14 +49,23 @@ OPTIONS:
 
 ### Package dependency cache
 
-Clones used by `--package-deps` are cached in a global, project-shared directory
-(`~/Library/Caches/LicenseCLI` on macOS, `~/.cache/LicenseCLI` on Linux) and reused
-across runs, keyed by `owner-name@version`. Entries unused for more than 30 days are
-pruned automatically. To clear the cache manually:
+By default, clones used by `--package-deps` are cached in a global, project-shared
+directory (`~/Library/Caches/LicenseCLI` on macOS, `~/.cache/LicenseCLI` on Linux) and
+reused across runs, keyed by `owner-name@version`. Entries unused for more than 30 days
+are pruned automatically. To clear the global cache manually:
 
 ```
 licensecli cache-prune
 ```
+
+You can override where clones are cached, or disable caching entirely:
+
+- `--package-deps-cache-dir <path>` — cache clones in `<path>` instead of the global
+  cache. This directory is used as-is and is **not** subject to automatic pruning.
+- `--no-cache` — skip the cache and clone into a temporary directory that is discarded
+  after the run.
+
+These two options are mutually exclusive.
 
 When you execute LicenseCLI, it generates `Licenses`. `Licenses` contain an `all` property, which stores the licenses of all dependencies used by the package.
 This is the Example code for use with SwiftUI:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,19 @@ Ryu0118/LicenseCLI@0.2.1
 
 # Usage
 ```
-USAGE: licensecli [<project-directory> ...] [--github-repo <github-repo> ...] [--package-deps <package-deps> ...] [--package-deps-cache-dir <package-deps-cache-dir>] --output-directory <output-directory> [--name <name>] [--verbose]
+USAGE: licensecli <subcommand>
+
+OPTIONS:
+  -h, --help              Show help information.
+
+SUBCOMMANDS:
+  generate (default)      Generate a license file (default command)
+  cache-prune             Remove all cached package dependency clones
+```
+
+### `generate` (default)
+```
+USAGE: licensecli generate [<project-directory> ...] [--github-repo <github-repo> ...] [--package-deps <package-deps> ...] --output-directory <output-directory> [--name <name>] [--verbose]
 
 ARGUMENTS:
   <project-directory>     Directories where Package.swift is located
@@ -23,13 +35,24 @@ OPTIONS:
                           GitHub repository URLs (e.g., https://github.com/owner/repo)
   --package-deps <package-deps>
                           GitHub repository URLs with dependencies (e.g., https://github.com/owner/repo@1.0.0)
-  --package-deps-cache-dir <package-deps-cache-dir>
-                          Cache directory for package dependencies clones (reuses existing clones if revision matches)
   -o, --output-directory <output-directory>
                           Output directory
   -n, --name <name>       (default: Licenses)
   --verbose               Enable verbose logging
   -h, --help              Show help information.
+```
+
+`generate` is the default subcommand, so `licensecli --output-directory ...` works the same as `licensecli generate --output-directory ...`.
+
+### Package dependency cache
+
+Clones used by `--package-deps` are cached in a global, project-shared directory
+(`~/Library/Caches/LicenseCLI` on macOS, `~/.cache/LicenseCLI` on Linux) and reused
+across runs, keyed by `owner-name@version`. Entries unused for more than 30 days are
+pruned automatically. To clear the cache manually:
+
+```
+licensecli cache-prune
 ```
 
 When you execute LicenseCLI, it generates `Licenses`. `Licenses` contain an `all` property, which stores the licenses of all dependencies used by the package.

--- a/Sources/LicenseCLI/CachePrune.swift
+++ b/Sources/LicenseCLI/CachePrune.swift
@@ -1,0 +1,22 @@
+import ArgumentParser
+import LicenseCLICore
+
+/// Removes every cached package clone from the global cache directory.
+///
+/// Cached clones are normally reused across projects and pruned automatically
+/// once unused beyond the TTL. This command clears the entire cache on demand.
+struct CachePrune: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "cache-prune",
+        abstract: "Remove all cached package dependency clones"
+    )
+
+    @Flag(name: .long, help: "Enable verbose logging")
+    var verbose: Bool = false
+
+    func run() throws {
+        LicenseCLICore.setupLogging(verbose: verbose)
+        let removed = try CacheDirectory().prune()
+        print("🧹 Pruned \(removed) cached package clone(s)")
+    }
+}

--- a/Sources/LicenseCLI/Generate.swift
+++ b/Sources/LicenseCLI/Generate.swift
@@ -22,6 +22,16 @@ struct Generate: AsyncParsableCommand {
     @Option(name: .long, parsing: .upToNextOption, help: "GitHub repository URLs with dependencies (e.g., https://github.com/owner/repo@1.0.0 or git@github.com:owner/repo.git@1.0.0)")
     var packageDeps: [String] = []
 
+    @Option(
+        name: .long,
+        help: "Cache package dependency clones in this directory instead of the global cache (no automatic pruning)",
+        completion: .directory
+    )
+    var packageDepsCacheDir: String?
+
+    @Flag(name: .long, help: "Disable caching; clone package dependencies into a temporary directory discarded after the run")
+    var noCache: Bool = false
+
     @Option(name: .shortAndLong, help: "Output directory", completion: .directory)
     var outputDirectory: String
 
@@ -31,18 +41,35 @@ struct Generate: AsyncParsableCommand {
     @Flag(name: .long, help: "Enable verbose logging")
     var verbose: Bool = false
 
+    var cacheLocation: CacheLocation {
+        if noCache {
+            .disabled
+        } else if let packageDepsCacheDir {
+            .custom(path: packageDepsCacheDir)
+        } else {
+            .global
+        }
+    }
+
     mutating func run() async throws {
         try await Runner().run(
             packageDirectoryPaths: projectDirectory,
             githubRepoURLs: githubRepo,
             packageDependenciesURLs: packageDeps,
+            cacheLocation: cacheLocation,
             outputDirectoryPath: outputDirectory,
             fileName: name
         )
     }
 
     mutating func validate() throws {
+        // Validate cheap, conflicting flags before the side-effecting logging init.
+        if noCache, packageDepsCacheDir != nil {
+            throw ValidationError("--no-cache and --package-deps-cache-dir cannot be used together")
+        }
+
         LicenseCLICore.setupLogging(verbose: verbose)
+
         try SwiftPackageValidator().validate(
             packageDirectoryPaths: projectDirectory,
             githubRepoURLs: githubRepo,

--- a/Sources/LicenseCLI/Generate.swift
+++ b/Sources/LicenseCLI/Generate.swift
@@ -1,0 +1,54 @@
+import ArgumentParser
+import LicenseCLICore
+
+/// Generates a Swift license file from package directories, GitHub repositories,
+/// and package dependencies.
+///
+/// Package dependency clones are cached in a global, project-shared cache directory
+/// and reused across runs. Stale entries are pruned automatically; use the
+/// `cache-prune` subcommand to clear the cache manually.
+struct Generate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "generate",
+        abstract: "Generate a license file (default command)"
+    )
+
+    @Argument(help: "Directories where Package.swift is located", completion: .directory)
+    var projectDirectory: [String] = []
+
+    @Option(name: .long, parsing: .upToNextOption, help: "GitHub repository URLs (e.g., https://github.com/owner/repo or git@github.com:owner/repo.git)")
+    var githubRepo: [String] = []
+
+    @Option(name: .long, parsing: .upToNextOption, help: "GitHub repository URLs with dependencies (e.g., https://github.com/owner/repo@1.0.0 or git@github.com:owner/repo.git@1.0.0)")
+    var packageDeps: [String] = []
+
+    @Option(name: .shortAndLong, help: "Output directory", completion: .directory)
+    var outputDirectory: String
+
+    @Option(name: .shortAndLong)
+    var name: String = "Licenses"
+
+    @Flag(name: .long, help: "Enable verbose logging")
+    var verbose: Bool = false
+
+    mutating func run() async throws {
+        try await Runner().run(
+            packageDirectoryPaths: projectDirectory,
+            githubRepoURLs: githubRepo,
+            packageDependenciesURLs: packageDeps,
+            outputDirectoryPath: outputDirectory,
+            fileName: name
+        )
+    }
+
+    mutating func validate() throws {
+        LicenseCLICore.setupLogging(verbose: verbose)
+        try SwiftPackageValidator().validate(
+            packageDirectoryPaths: projectDirectory,
+            githubRepoURLs: githubRepo,
+            packageDependenciesURLs: packageDeps,
+            outputDirectoryPath: outputDirectory,
+            fileName: name
+        )
+    }
+}

--- a/Sources/LicenseCLI/LicenseCLI.swift
+++ b/Sources/LicenseCLI/LicenseCLI.swift
@@ -1,50 +1,11 @@
 import ArgumentParser
-import LicenseCLICore
 
 @main
 struct LicenseCLI: AsyncParsableCommand {
-    @Argument(help: "Directories where Package.swift is located", completion: .directory)
-    var projectDirectory: [String] = []
-
-    @Option(name: .long, parsing: .upToNextOption, help: "GitHub repository URLs (e.g., https://github.com/owner/repo or git@github.com:owner/repo.git)")
-    var githubRepo: [String] = []
-
-    @Option(name: .long, parsing: .upToNextOption, help: "GitHub repository URLs with dependencies (e.g., https://github.com/owner/repo@1.0.0 or git@github.com:owner/repo.git@1.0.0)")
-    var packageDeps: [String] = []
-
-    @Option(name: .long, help: "Cache directory for package dependencies clones (reuses existing clones if revision matches)", completion: .directory)
-    var packageDepsCacheDir: String?
-
-    @Option(name: .shortAndLong, help: "Output directory", completion: .directory)
-    var outputDirectory: String
-
-    @Option(name: .shortAndLong)
-    var name: String = "Licenses"
-
-    @Flag(name: .long, help: "Enable verbose logging")
-    var verbose: Bool = false
-
-    static let configuration = CommandConfiguration(commandName: "licensecli")
-
-    mutating func run() async throws {
-        try await Runner().run(
-            packageDirectoryPaths: projectDirectory,
-            githubRepoURLs: githubRepo,
-            packageDependenciesURLs: packageDeps,
-            packageDepsCacheDirectory: packageDepsCacheDir,
-            outputDirectoryPath: outputDirectory,
-            fileName: name
-        )
-    }
-
-    mutating func validate() throws {
-        LicenseCLICore.setupLogging(verbose: verbose)
-        try SwiftPackageValidator().validate(
-            packageDirectoryPaths: projectDirectory,
-            githubRepoURLs: githubRepo,
-            packageDependenciesURLs: packageDeps,
-            outputDirectoryPath: outputDirectory,
-            fileName: name
-        )
-    }
+    static let configuration = CommandConfiguration(
+        commandName: "licensecli",
+        abstract: "Generate a Swift license file from packages and dependencies.",
+        subcommands: [Generate.self, CachePrune.self],
+        defaultSubcommand: Generate.self
+    )
 }

--- a/Sources/LicenseCLICore/CacheDirectory.swift
+++ b/Sources/LicenseCLICore/CacheDirectory.swift
@@ -1,13 +1,40 @@
 import Foundation
 
-/// Manages the global cache directory for package dependency clones.
+/// Where package dependency clones should be cached for a run.
+public enum CacheLocation: Equatable {
+    /// The global, OS-managed cache (the default).
+    case global
+    /// A user-supplied directory used directly (`--package-deps-cache-dir`).
+    case custom(path: String)
+    /// No caching; clones go to a temporary directory discarded after the run (`--no-cache`).
+    case disabled
+
+    /// The cache to use, or `nil` when caching is disabled.
+    public func cacheDirectory(fileManager: FileManager = .default) -> CacheDirectory? {
+        switch self {
+        case .global:
+            CacheDirectory(fileManager: fileManager)
+        case let .custom(path):
+            CacheDirectory(customPath: path, fileManager: fileManager)
+        case .disabled:
+            nil
+        }
+    }
+}
+
+/// Manages a cache directory for package dependency clones.
 ///
-/// Clones are stored in the OS cache directory, keyed only by `owner-name@version`
-/// (not by project path), so the same library at the same version is shared across
-/// all projects — similar to a pnpm-style global store.
+/// Clones are keyed only by `owner-name@version` (not by project path), so the same
+/// library at the same version is shared across runs — similar to a pnpm-style store.
 ///
-/// On macOS this resolves to `~/Library/Caches/LicenseCLI`, and on Linux to
-/// `~/.cache/LicenseCLI` (XDG), via `FileManager`'s `.cachesDirectory`.
+/// Two layouts exist:
+/// - **global** (the default): the OS cache directory with a `LicenseCLI` subdirectory
+///   appended — `~/Library/Caches/LicenseCLI` on macOS, `~/.cache/LicenseCLI` on Linux
+///   (via `FileManager`'s `.cachesDirectory`). Eligible for automatic TTL garbage
+///   collection.
+/// - **custom** (`--package-deps-cache-dir`): the user-supplied path used directly,
+///   with no subdirectory appended and no TTL garbage collection, preserving the prior
+///   behavior of that option.
 public struct CacheDirectory {
     /// Number of days a cached clone may remain unused before it is eligible for
     /// automatic time-to-live (TTL) garbage collection.
@@ -15,29 +42,45 @@ public struct CacheDirectory {
 
     let fileManager: FileManager
 
-    /// Resolves the base directory that `LicenseCLI` is appended to. Defaults to the
-    /// OS caches directory; overridable for testing.
-    private let baseDirectoryURL: () throws -> URL
+    /// Whether this is the global, OS-managed cache. Only the global cache is subject
+    /// to automatic TTL garbage collection.
+    let isGlobal: Bool
 
+    /// Resolves the root cache directory (already including any `LicenseCLI` subdir).
+    /// Overridable for testing.
+    private let resolveRootURL: () throws -> URL
+
+    /// The global OS cache (`<OS caches>/LicenseCLI`).
     public init(fileManager: FileManager = .default) {
-        self.init(fileManager: fileManager) {
+        self.init(fileManager: fileManager, isGlobal: true) {
             try fileManager.url(
                 for: .cachesDirectory,
                 in: .userDomainMask,
                 appropriateFor: nil,
                 create: true
             )
+            .appendingPathComponent("LicenseCLI")
         }
     }
 
-    init(fileManager: FileManager, baseDirectoryURL: @escaping () throws -> URL) {
-        self.fileManager = fileManager
-        self.baseDirectoryURL = baseDirectoryURL
+    /// A custom cache at `path`, used directly without a `LicenseCLI` subdirectory and
+    /// exempt from TTL garbage collection (preserving the prior `--package-deps-cache-dir`
+    /// behavior).
+    public init(customPath: String, fileManager: FileManager = .default) {
+        self.init(fileManager: fileManager, isGlobal: false) {
+            URL(fileURLWithPath: customPath)
+        }
     }
 
-    /// The root cache directory (`<base>/LicenseCLI`), created if needed.
+    init(fileManager: FileManager, isGlobal: Bool, resolveRootURL: @escaping () throws -> URL) {
+        self.fileManager = fileManager
+        self.isGlobal = isGlobal
+        self.resolveRootURL = resolveRootURL
+    }
+
+    /// The root cache directory, created if needed.
     func rootURL() throws -> URL {
-        let rootURL = try baseDirectoryURL().appendingPathComponent("LicenseCLI")
+        let rootURL = try resolveRootURL()
         // `withIntermediateDirectories: true` is idempotent and does not throw if it exists.
         try fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
         return rootURL
@@ -67,9 +110,11 @@ public struct CacheDirectory {
 
     /// Removes cache entries whose last use is older than `timeToLiveDays`.
     ///
+    /// Only applies to the global cache; a custom cache directory is left untouched.
     /// Called automatically on each run. Failures are logged and ignored — GC must
     /// never break a license-generation run.
     func collectGarbage() {
+        guard isGlobal else { return }
         guard let rootURL = try? rootURL() else { return }
 
         let cutoff = Date(timeIntervalSinceNow: -Double(Self.timeToLiveDays) * 24 * 60 * 60)

--- a/Sources/LicenseCLICore/CacheDirectory.swift
+++ b/Sources/LicenseCLICore/CacheDirectory.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Manages the global cache directory for package dependency clones.
+///
+/// Clones are stored in the OS cache directory, keyed only by `owner-name@version`
+/// (not by project path), so the same library at the same version is shared across
+/// all projects — similar to a pnpm-style global store.
+///
+/// On macOS this resolves to `~/Library/Caches/LicenseCLI`, and on Linux to
+/// `~/.cache/LicenseCLI` (XDG), via `FileManager`'s `.cachesDirectory`.
+public struct CacheDirectory {
+    /// Number of days a cached clone may remain unused before it is eligible for
+    /// automatic time-to-live (TTL) garbage collection.
+    static let timeToLiveDays = 30
+
+    let fileManager: FileManager
+
+    /// Resolves the base directory that `LicenseCLI` is appended to. Defaults to the
+    /// OS caches directory; overridable for testing.
+    private let baseDirectoryURL: () throws -> URL
+
+    public init(fileManager: FileManager = .default) {
+        self.init(fileManager: fileManager) {
+            try fileManager.url(
+                for: .cachesDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        }
+    }
+
+    init(fileManager: FileManager, baseDirectoryURL: @escaping () throws -> URL) {
+        self.fileManager = fileManager
+        self.baseDirectoryURL = baseDirectoryURL
+    }
+
+    /// The root cache directory (`<base>/LicenseCLI`), created if needed.
+    func rootURL() throws -> URL {
+        let rootURL = try baseDirectoryURL().appendingPathComponent("LicenseCLI")
+        // `withIntermediateDirectories: true` is idempotent and does not throw if it exists.
+        try fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        return rootURL
+    }
+
+    /// The cache directory for a specific repository and version.
+    ///
+    /// Entries are keyed only by `owner-name@version` (not by project path), so the
+    /// same library at the same version is shared across all projects.
+    func entryURL(for repoWithVersion: GitHubRepoWithVersion) throws -> URL {
+        let repo = repoWithVersion.repo
+        let version = repoWithVersion.version.gitReference
+        // Sanitize the directory name: replace path separators (/ and :) with -.
+        let dirName = "\(repo.owner)-\(repo.name)@\(version)"
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+        return try rootURL().appendingPathComponent(dirName)
+    }
+
+    /// Marks a cache entry as recently used by updating its modification date.
+    ///
+    /// The TTL garbage collector relies on this timestamp to decide what is stale,
+    /// so every cache hit/creation must touch the entry.
+    func touch(_ url: URL) {
+        try? fileManager.setAttributes([.modificationDate: Date()], ofItemAtPath: url.path)
+    }
+
+    /// Removes cache entries whose last use is older than `timeToLiveDays`.
+    ///
+    /// Called automatically on each run. Failures are logged and ignored — GC must
+    /// never break a license-generation run.
+    func collectGarbage() {
+        guard let rootURL = try? rootURL() else { return }
+
+        let cutoff = Date(timeIntervalSinceNow: -Double(Self.timeToLiveDays) * 24 * 60 * 60)
+        let entries = (try? fileManager.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        for entry in entries {
+            let modificationDate = (try? entry.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate
+            guard let modificationDate, modificationDate < cutoff else { continue }
+
+            logger.trace("🧹 Removing stale cache entry: \(entry.lastPathComponent)")
+            try? fileManager.removeItem(at: entry)
+        }
+    }
+
+    /// Removes every cache entry (the `prune` command).
+    /// Returns the number of entries removed.
+    @discardableResult
+    public func prune() throws -> Int {
+        let rootURL = try rootURL()
+        let entries = try fileManager.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+
+        for entry in entries {
+            try fileManager.removeItem(at: entry)
+        }
+        return entries.count
+    }
+}

--- a/Sources/LicenseCLICore/GitHubRepoWithVersion.swift
+++ b/Sources/LicenseCLICore/GitHubRepoWithVersion.swift
@@ -4,6 +4,11 @@ struct GitHubRepoWithVersion {
     let repo: GitHubRepo
     let version: Version
 
+    init(repo: GitHubRepo, version: Version) {
+        self.repo = repo
+        self.version = version
+    }
+
     enum Version: Equatable {
         case branch(String)
         case tag(String)

--- a/Sources/LicenseCLICore/PackageDependenciesResolver.swift
+++ b/Sources/LicenseCLICore/PackageDependenciesResolver.swift
@@ -3,6 +3,7 @@ import Foundation
 enum PackageDependenciesResolverError: LocalizedError {
     case invalidURL(String)
     case packageResolveFailed(String)
+    case temporaryDirectoryCreationFailed
     case noPackageResolvedGenerated
 
     var errorDescription: String? {
@@ -11,6 +12,8 @@ enum PackageDependenciesResolverError: LocalizedError {
             "Invalid package URL: \(url)"
         case let .packageResolveFailed(message):
             "Failed to resolve package: \(message)"
+        case .temporaryDirectoryCreationFailed:
+            "Failed to create temporary directory"
         case .noPackageResolvedGenerated:
             "Package.resolved was not generated (package may have no dependencies)"
         }
@@ -20,7 +23,10 @@ enum PackageDependenciesResolverError: LocalizedError {
 struct PackageDependenciesResolver {
     let fileManager: FileManager
     let dependenciesLoader: DependenciesLoader
-    let cacheDirectory: CacheDirectory
+
+    /// The cache to use, or `nil` to clone into a temporary directory discarded after
+    /// the run (`--no-cache`).
+    let cacheDirectory: CacheDirectory?
 
     init(
         fileManager: FileManager = .default,
@@ -28,7 +34,7 @@ struct PackageDependenciesResolver {
             fileManager: .default,
             jsonDecoder: JSONDecoder()
         ),
-        cacheDirectory: CacheDirectory = CacheDirectory()
+        cacheDirectory: CacheDirectory? = CacheDirectory()
     ) {
         self.fileManager = fileManager
         self.dependenciesLoader = dependenciesLoader
@@ -37,12 +43,47 @@ struct PackageDependenciesResolver {
 
     /// Resolve dependencies for a package from a GitHub repository.
     ///
-    /// Clones are cached in the global cache directory and shared across projects,
-    /// keyed by `owner-name@version`. Returns the dependencies from Package.resolved,
-    /// or nil if no dependencies exist.
+    /// When a cache is configured, clones are reused across runs keyed by
+    /// `owner-name@version`; otherwise the clone is made in a temporary directory and
+    /// discarded. Returns the dependencies from Package.resolved, or nil if none exist.
     func resolve(repoWithVersion: GitHubRepoWithVersion) throws -> Dependencies? {
         logger.info("🔍 Resolving dependencies for \(repoWithVersion.repo.identity)")
 
+        let workDirectory: URL
+        let shouldCleanup: Bool
+
+        if let cacheDirectory {
+            workDirectory = try cachedClone(repoWithVersion: repoWithVersion, in: cacheDirectory)
+            shouldCleanup = false
+        } else {
+            workDirectory = try createTemporaryDirectory()
+            shouldCleanup = true
+            logger.trace("Created temporary directory: \(workDirectory.path)")
+            try cloneRepository(repoWithVersion: repoWithVersion, to: workDirectory)
+        }
+
+        defer {
+            if shouldCleanup {
+                cleanup(directory: workDirectory)
+            }
+        }
+
+        // Run swift package resolve
+        let packageResolvedExists = try runSwiftPackageResolve(at: workDirectory)
+
+        // If Package.resolved was not generated, the package has no dependencies
+        guard packageResolvedExists else {
+            logger.info("📦 Package has no dependencies")
+            return nil
+        }
+
+        // Load and return dependencies
+        return try dependenciesLoader.load(packageDirectoryPath: workDirectory.path)
+    }
+
+    /// Returns a ready-to-use clone in the cache, reusing an existing one when its
+    /// revision matches and re-cloning otherwise.
+    private func cachedClone(repoWithVersion: GitHubRepoWithVersion, in cacheDirectory: CacheDirectory) throws -> URL {
         let repoCacheDir = try cacheDirectory.entryURL(for: repoWithVersion)
 
         let workDirectory: URL
@@ -70,18 +111,33 @@ struct PackageDependenciesResolver {
 
         // Mark this entry as recently used so the TTL collector keeps it around.
         cacheDirectory.touch(workDirectory)
+        return workDirectory
+    }
 
-        // Run swift package resolve
-        let packageResolvedExists = try runSwiftPackageResolve(at: workDirectory)
+    private func createTemporaryDirectory() throws -> URL {
+        let tempDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("licensecli-\(UUID().uuidString)")
 
-        // If Package.resolved was not generated, the package has no dependencies
-        guard packageResolvedExists else {
-            logger.info("📦 Package has no dependencies")
-            return nil
+        do {
+            try fileManager.createDirectory(
+                at: tempDirectory,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            return tempDirectory
+        } catch {
+            logger.error("Failed to create temporary directory: \(error)")
+            throw PackageDependenciesResolverError.temporaryDirectoryCreationFailed
         }
+    }
 
-        // Load and return dependencies
-        return try dependenciesLoader.load(packageDirectoryPath: workDirectory.path)
+    private func cleanup(directory: URL) {
+        do {
+            try fileManager.removeItem(at: directory)
+            logger.trace("Cleaned up temporary directory: \(directory.path)")
+        } catch {
+            logger.warning("Failed to cleanup temporary directory: \(error)")
+        }
     }
 
     private func cloneRepository(repoWithVersion: GitHubRepoWithVersion, to destination: URL) throws {

--- a/Sources/LicenseCLICore/PackageDependenciesResolver.swift
+++ b/Sources/LicenseCLICore/PackageDependenciesResolver.swift
@@ -3,7 +3,6 @@ import Foundation
 enum PackageDependenciesResolverError: LocalizedError {
     case invalidURL(String)
     case packageResolveFailed(String)
-    case temporaryDirectoryCreationFailed
     case noPackageResolvedGenerated
 
     var errorDescription: String? {
@@ -12,8 +11,6 @@ enum PackageDependenciesResolverError: LocalizedError {
             "Invalid package URL: \(url)"
         case let .packageResolveFailed(message):
             "Failed to resolve package: \(message)"
-        case .temporaryDirectoryCreationFailed:
-            "Failed to create temporary directory"
         case .noPackageResolvedGenerated:
             "Package.resolved was not generated (package may have no dependencies)"
         }
@@ -23,67 +20,56 @@ enum PackageDependenciesResolverError: LocalizedError {
 struct PackageDependenciesResolver {
     let fileManager: FileManager
     let dependenciesLoader: DependenciesLoader
+    let cacheDirectory: CacheDirectory
 
     init(
         fileManager: FileManager = .default,
         dependenciesLoader: DependenciesLoader = DependenciesLoader(
             fileManager: .default,
             jsonDecoder: JSONDecoder()
-        )
+        ),
+        cacheDirectory: CacheDirectory = CacheDirectory()
     ) {
         self.fileManager = fileManager
         self.dependenciesLoader = dependenciesLoader
+        self.cacheDirectory = cacheDirectory
     }
 
-    /// Resolve dependencies for a package from a GitHub repository
-    /// Returns the dependencies from Package.resolved, or nil if no dependencies exist
-    func resolve(repoWithVersion: GitHubRepoWithVersion, cacheDirectory: String?) throws -> Dependencies? {
+    /// Resolve dependencies for a package from a GitHub repository.
+    ///
+    /// Clones are cached in the global cache directory and shared across projects,
+    /// keyed by `owner-name@version`. Returns the dependencies from Package.resolved,
+    /// or nil if no dependencies exist.
+    func resolve(repoWithVersion: GitHubRepoWithVersion) throws -> Dependencies? {
         logger.info("🔍 Resolving dependencies for \(repoWithVersion.repo.identity)")
 
+        let repoCacheDir = try cacheDirectory.entryURL(for: repoWithVersion)
+
         let workDirectory: URL
-        let shouldCleanup: Bool
-
-        if let cacheDir = cacheDirectory {
-            // Use cache directory
-            let cacheURL = URL(fileURLWithPath: cacheDir)
-            let repoCacheDir = getCacheDirectory(for: repoWithVersion, in: cacheURL)
-
-            // Check if cached directory exists and has the correct revision
-            if let existingDir = try getExistingCacheDirectory(repoWithVersion: repoWithVersion, cacheDir: repoCacheDir) {
-                logger.info("♻️ Using cached clone at \(existingDir.path)")
-                workDirectory = existingDir
-                shouldCleanup = false
-            } else {
-                // Remove existing directory if it exists but has wrong revision
-                if fileManager.fileExists(atPath: repoCacheDir.path) {
-                    logger.info("🗑️ Removing outdated cache directory: \(repoCacheDir.path)")
-                    try? fileManager.removeItem(at: repoCacheDir)
-                }
-
-                // Create cache directory and clone
-                try fileManager.createDirectory(
-                    at: repoCacheDir,
-                    withIntermediateDirectories: true,
-                    attributes: nil
-                )
-                logger.info("📥 Cloning to cache directory: \(repoCacheDir.path)")
-                try cloneRepository(repoWithVersion: repoWithVersion, to: repoCacheDir)
-                workDirectory = repoCacheDir
-                shouldCleanup = false
-            }
+        // Check if cached directory exists and has the correct revision
+        if let existingDir = try getExistingCacheDirectory(repoWithVersion: repoWithVersion, cacheDir: repoCacheDir) {
+            logger.info("♻️ Using cached clone at \(existingDir.path)")
+            workDirectory = existingDir
         } else {
-            // Use temporary directory (original behavior)
-            workDirectory = try createTemporaryDirectory()
-            shouldCleanup = true
-            logger.trace("Created temporary directory: \(workDirectory.path)")
-            try cloneRepository(repoWithVersion: repoWithVersion, to: workDirectory)
+            // Remove existing directory if it exists but has wrong revision
+            if fileManager.fileExists(atPath: repoCacheDir.path) {
+                logger.info("🗑️ Removing outdated cache directory: \(repoCacheDir.path)")
+                try? fileManager.removeItem(at: repoCacheDir)
+            }
+
+            // Create cache directory and clone
+            try fileManager.createDirectory(
+                at: repoCacheDir,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            logger.info("📥 Cloning to cache directory: \(repoCacheDir.path)")
+            try cloneRepository(repoWithVersion: repoWithVersion, to: repoCacheDir)
+            workDirectory = repoCacheDir
         }
 
-        defer {
-            if shouldCleanup {
-                cleanup(directory: workDirectory)
-            }
-        }
+        // Mark this entry as recently used so the TTL collector keeps it around.
+        cacheDirectory.touch(workDirectory)
 
         // Run swift package resolve
         let packageResolvedExists = try runSwiftPackageResolve(at: workDirectory)
@@ -96,23 +82,6 @@ struct PackageDependenciesResolver {
 
         // Load and return dependencies
         return try dependenciesLoader.load(packageDirectoryPath: workDirectory.path)
-    }
-
-    private func createTemporaryDirectory() throws -> URL {
-        let tempDirectory = fileManager.temporaryDirectory
-            .appendingPathComponent("licensecli-\(UUID().uuidString)")
-
-        do {
-            try fileManager.createDirectory(
-                at: tempDirectory,
-                withIntermediateDirectories: true,
-                attributes: nil
-            )
-            return tempDirectory
-        } catch {
-            logger.error("Failed to create temporary directory: \(error)")
-            throw PackageDependenciesResolverError.temporaryDirectoryCreationFailed
-        }
     }
 
     private func cloneRepository(repoWithVersion: GitHubRepoWithVersion, to destination: URL) throws {
@@ -165,26 +134,6 @@ struct PackageDependenciesResolver {
             logger.error("Failed to resolve package: \(error)")
             throw PackageDependenciesResolverError.packageResolveFailed(error.localizedDescription)
         }
-    }
-
-    private func cleanup(directory: URL) {
-        do {
-            try fileManager.removeItem(at: directory)
-            logger.trace("Cleaned up temporary directory: \(directory.path)")
-        } catch {
-            logger.warning("Failed to cleanup temporary directory: \(error)")
-        }
-    }
-
-    /// Get cache directory path for a specific repository and version
-    private func getCacheDirectory(for repoWithVersion: GitHubRepoWithVersion, in cacheBaseURL: URL) -> URL {
-        let repo = repoWithVersion.repo
-        let version = repoWithVersion.version.gitReference
-        // Sanitize directory name: replace / with - and @ with @
-        let dirName = "\(repo.owner)-\(repo.name)@\(version)"
-            .replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: ":", with: "-")
-        return cacheBaseURL.appendingPathComponent(dirName)
     }
 
     /// Check if an existing cache directory exists and can be used for the target revision

--- a/Sources/LicenseCLICore/Runner.swift
+++ b/Sources/LicenseCLICore/Runner.swift
@@ -22,11 +22,14 @@ public struct Runner {
         packageDirectoryPaths: [String],
         githubRepoURLs: [String],
         packageDependenciesURLs: [String],
-        packageDepsCacheDirectory: String?,
         outputDirectoryPath: String,
         fileName: String
     ) async throws {
         logger.info("\(ANSIColor.colored("🚀 Starting license generation", color: .cyan))")
+
+        // Drop cache entries unused beyond the TTL before doing any work.
+        CacheDirectory().collectGarbage()
+
         logger.trace("Package directories: \(packageDirectoryPaths)")
         logger.trace("GitHub repository URLs: \(githubRepoURLs)")
         logger.trace("Package dependency URLs: \(packageDependenciesURLs)")
@@ -51,10 +54,7 @@ public struct Runner {
         licenses.formUnion(githubLicenses)
 
         // Process package dependencies (--package-deps option)
-        let packageDepsLicenses = try await processPackageDependencies(
-            packageDependenciesURLs,
-            cacheDirectory: packageDepsCacheDirectory
-        )
+        let packageDepsLicenses = try await processPackageDependencies(packageDependenciesURLs)
         licenses.formUnion(packageDepsLicenses)
 
         logger.info("📦 Loaded \(licenses.count) unique licenses")
@@ -73,7 +73,7 @@ public struct Runner {
         logger.info("\(ANSIColor.colored("✅ Successfully generated license file at \(outputURL.path)", color: .green))")
     }
 
-    private func processPackageDependencies(_ packageDependenciesURLs: [String], cacheDirectory: String?) async throws -> Set<License> {
+    private func processPackageDependencies(_ packageDependenciesURLs: [String]) async throws -> Set<License> {
         guard !packageDependenciesURLs.isEmpty else { return [] }
 
         logger.info("🔧 Processing \(packageDependenciesURLs.count) package dependency URL(s)")
@@ -98,8 +98,7 @@ public struct Runner {
 
                     // Then resolve and fetch licenses for all dependencies
                     if let dependencies = try packageDependenciesResolver.resolve(
-                        repoWithVersion: repoWithVersion,
-                        cacheDirectory: cacheDirectory
+                        repoWithVersion: repoWithVersion
                     ) {
                         let dependencyLicenses = try await licenseLoader.load(for: dependencies)
                         allLicenses.append(contentsOf: dependencyLicenses)

--- a/Sources/LicenseCLICore/Runner.swift
+++ b/Sources/LicenseCLICore/Runner.swift
@@ -1,34 +1,40 @@
 import Foundation
 
 public struct Runner {
+    private let fileManager: FileManager
     private let dependenciesLoader: DependenciesLoader
     private let licenseLoader: LicenseLoader
-    private let packageDependenciesResolver: PackageDependenciesResolver
 
     public init(
         fileManager: FileManager = .default,
         jsonDecoder: JSONDecoder = .init(),
         urlSession: URLSession = .shared
     ) {
+        self.fileManager = fileManager
         dependenciesLoader = DependenciesLoader(fileManager: fileManager, jsonDecoder: jsonDecoder)
         licenseLoader = LicenseLoader(urlSession: urlSession)
-        packageDependenciesResolver = PackageDependenciesResolver(
-            fileManager: fileManager,
-            dependenciesLoader: dependenciesLoader
-        )
     }
 
     public func run(
         packageDirectoryPaths: [String],
         githubRepoURLs: [String],
         packageDependenciesURLs: [String],
+        cacheLocation: CacheLocation = .global,
         outputDirectoryPath: String,
         fileName: String
     ) async throws {
         logger.info("\(ANSIColor.colored("🚀 Starting license generation", color: .cyan))")
 
+        let cacheDirectory = cacheLocation.cacheDirectory(fileManager: fileManager)
+        let packageDependenciesResolver = PackageDependenciesResolver(
+            fileManager: fileManager,
+            dependenciesLoader: dependenciesLoader,
+            cacheDirectory: cacheDirectory
+        )
+
         // Drop cache entries unused beyond the TTL before doing any work.
-        CacheDirectory().collectGarbage()
+        // No-op unless this is the global cache.
+        cacheDirectory?.collectGarbage()
 
         logger.trace("Package directories: \(packageDirectoryPaths)")
         logger.trace("GitHub repository URLs: \(githubRepoURLs)")
@@ -54,7 +60,10 @@ public struct Runner {
         licenses.formUnion(githubLicenses)
 
         // Process package dependencies (--package-deps option)
-        let packageDepsLicenses = try await processPackageDependencies(packageDependenciesURLs)
+        let packageDepsLicenses = try await processPackageDependencies(
+            packageDependenciesURLs,
+            resolver: packageDependenciesResolver
+        )
         licenses.formUnion(packageDepsLicenses)
 
         logger.info("📦 Loaded \(licenses.count) unique licenses")
@@ -73,7 +82,10 @@ public struct Runner {
         logger.info("\(ANSIColor.colored("✅ Successfully generated license file at \(outputURL.path)", color: .green))")
     }
 
-    private func processPackageDependencies(_ packageDependenciesURLs: [String]) async throws -> Set<License> {
+    private func processPackageDependencies(
+        _ packageDependenciesURLs: [String],
+        resolver packageDependenciesResolver: PackageDependenciesResolver
+    ) async throws -> Set<License> {
         guard !packageDependenciesURLs.isEmpty else { return [] }
 
         logger.info("🔧 Processing \(packageDependenciesURLs.count) package dependency URL(s)")

--- a/Tests/LicenseCLITests/CacheDirectoryTests.swift
+++ b/Tests/LicenseCLITests/CacheDirectoryTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+@testable import LicenseCLICore
+import Testing
+
+@Suite
+final class CacheDirectoryTests {
+    let fileManager = FileManager.default
+    let baseURL: URL
+    let cache: CacheDirectory
+
+    init() throws {
+        baseURL = fileManager.temporaryDirectory
+            .appendingPathComponent("licensecli-cache-tests-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        cache = CacheDirectory(fileManager: fileManager) { [baseURL] in baseURL }
+    }
+
+    deinit {
+        try? fileManager.removeItem(at: baseURL)
+    }
+
+    private func makeEntry(_ name: String, modifiedDaysAgo days: Int) throws -> URL {
+        let root = try cache.rootURL()
+        let entry = root.appendingPathComponent(name)
+        try fileManager.createDirectory(at: entry, withIntermediateDirectories: true)
+        let date = Date(timeIntervalSinceNow: -Double(days) * 24 * 60 * 60)
+        try fileManager.setAttributes([.modificationDate: date], ofItemAtPath: entry.path)
+        return entry
+    }
+
+    @Test
+    func rootURLIsCreatedUnderBase() throws {
+        let root = try cache.rootURL()
+        #expect(root.lastPathComponent == "LicenseCLI")
+        #expect(fileManager.fileExists(atPath: root.path))
+    }
+
+    @Test
+    func collectGarbageRemovesStaleEntriesOnly() throws {
+        let fresh = try makeEntry("fresh@1.0.0", modifiedDaysAgo: 1)
+        let stale = try makeEntry("stale@1.0.0", modifiedDaysAgo: CacheDirectory.timeToLiveDays + 1)
+
+        cache.collectGarbage()
+
+        #expect(fileManager.fileExists(atPath: fresh.path))
+        #expect(!fileManager.fileExists(atPath: stale.path))
+    }
+
+    @Test
+    func touchKeepsEntryFromBeingCollected() throws {
+        let entry = try makeEntry("old@1.0.0", modifiedDaysAgo: CacheDirectory.timeToLiveDays + 5)
+
+        cache.touch(entry)
+        cache.collectGarbage()
+
+        #expect(fileManager.fileExists(atPath: entry.path))
+    }
+
+    @Test
+    func pruneRemovesAllEntriesAndReportsCount() throws {
+        _ = try makeEntry("a@1.0.0", modifiedDaysAgo: 1)
+        _ = try makeEntry("b@2.0.0", modifiedDaysAgo: 1)
+
+        let removed = try cache.prune()
+
+        #expect(removed == 2)
+        let remaining = try fileManager.contentsOfDirectory(atPath: cache.rootURL().path)
+        #expect(remaining.isEmpty)
+    }
+}

--- a/Tests/LicenseCLITests/CacheDirectoryTests.swift
+++ b/Tests/LicenseCLITests/CacheDirectoryTests.swift
@@ -12,7 +12,8 @@ final class CacheDirectoryTests {
         baseURL = fileManager.temporaryDirectory
             .appendingPathComponent("licensecli-cache-tests-\(UUID().uuidString)")
         try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
-        cache = CacheDirectory(fileManager: fileManager) { [baseURL] in baseURL }
+        // Treat the temp dir as a global cache root so TTL GC applies in tests.
+        cache = CacheDirectory(fileManager: fileManager, isGlobal: true) { [baseURL] in baseURL }
     }
 
     deinit {
@@ -29,9 +30,8 @@ final class CacheDirectoryTests {
     }
 
     @Test
-    func rootURLIsCreatedUnderBase() throws {
+    func rootURLIsCreated() throws {
         let root = try cache.rootURL()
-        #expect(root.lastPathComponent == "LicenseCLI")
         #expect(fileManager.fileExists(atPath: root.path))
     }
 
@@ -78,7 +78,7 @@ final class CacheDirectoryTests {
         let entry = try cache.entryURL(for: repo)
 
         #expect(entry.lastPathComponent == "apple-swift-nio@2.0.0")
-        #expect(try entry.deletingLastPathComponent() == (cache.rootURL()))
+        #expect(try entry.deletingLastPathComponent().standardizedFileURL == (cache.rootURL().standardizedFileURL))
     }
 
     /// Adversarial inputs must stay confined to the cache root: the security review's
@@ -103,5 +103,34 @@ final class CacheDirectoryTests {
         // are sanitized away, so `..` can never land at a path boundary.
         #expect(!entry.lastPathComponent.contains("/"))
         #expect(entry.standardizedFileURL.path.hasPrefix(root.standardizedFileURL.path))
+    }
+
+    @Test
+    func customCacheUsesPathDirectlyWithoutSubdirectory() throws {
+        let customRoot = baseURL.appendingPathComponent("custom-\(UUID().uuidString)")
+        let custom = CacheDirectory(customPath: customRoot.path, fileManager: fileManager)
+
+        let root = try custom.rootURL()
+
+        // The user-supplied path is used directly — no "LicenseCLI" subdirectory.
+        #expect(root.standardizedFileURL.path == customRoot.standardizedFileURL.path)
+        #expect(root.lastPathComponent != "LicenseCLI")
+    }
+
+    @Test
+    func customCacheIsExemptFromGarbageCollection() throws {
+        let customRoot = baseURL.appendingPathComponent("custom-\(UUID().uuidString)")
+        let custom = CacheDirectory(customPath: customRoot.path, fileManager: fileManager)
+        let root = try custom.rootURL()
+
+        let stale = root.appendingPathComponent("stale@1.0.0")
+        try fileManager.createDirectory(at: stale, withIntermediateDirectories: true)
+        let oldDate = Date(timeIntervalSinceNow: -Double(CacheDirectory.timeToLiveDays + 10) * 24 * 60 * 60)
+        try fileManager.setAttributes([.modificationDate: oldDate], ofItemAtPath: stale.path)
+
+        custom.collectGarbage()
+
+        // A custom cache is never pruned, even when entries are well past the TTL.
+        #expect(fileManager.fileExists(atPath: stale.path))
     }
 }

--- a/Tests/LicenseCLITests/CacheDirectoryTests.swift
+++ b/Tests/LicenseCLITests/CacheDirectoryTests.swift
@@ -67,4 +67,41 @@ final class CacheDirectoryTests {
         let remaining = try fileManager.contentsOfDirectory(atPath: cache.rootURL().path)
         #expect(remaining.isEmpty)
     }
+
+    @Test
+    func entryURLKeysOnOwnerNameAndVersion() throws {
+        let repo = GitHubRepoWithVersion(
+            repo: GitHubRepo(owner: "apple", name: "swift-nio"),
+            version: .tag("2.0.0")
+        )
+
+        let entry = try cache.entryURL(for: repo)
+
+        #expect(entry.lastPathComponent == "apple-swift-nio@2.0.0")
+        #expect(try entry.deletingLastPathComponent() == (cache.rootURL()))
+    }
+
+    /// Adversarial inputs must stay confined to the cache root: the security review's
+    /// no-path-traversal conclusion rests entirely on `entryURL`'s sanitization, so this
+    /// turns that claim into a regression test.
+    @Test(arguments: [
+        "../../etc",
+        "foo/../bar",
+        "feature/branch",
+        "git@host:x",
+    ])
+    func entryURLConfinesPathTraversalAttempts(version: String) throws {
+        let repo = GitHubRepoWithVersion(
+            repo: GitHubRepo(owner: "apple", name: "swift-nio"),
+            version: .tag(version)
+        )
+
+        let entry = try cache.entryURL(for: repo)
+        let root = try cache.rootURL()
+
+        // The entry is a single literal component directly under the root — separators
+        // are sanitized away, so `..` can never land at a path boundary.
+        #expect(!entry.lastPathComponent.contains("/"))
+        #expect(entry.standardizedFileURL.path.hasPrefix(root.standardizedFileURL.path))
+    }
 }

--- a/Tests/LicenseCLITests/GenerateValidationTests.swift
+++ b/Tests/LicenseCLITests/GenerateValidationTests.swift
@@ -1,0 +1,40 @@
+import ArgumentParser
+@testable import LicenseCLI
+@testable import LicenseCLICore
+import Testing
+
+@Suite
+struct GenerateValidationTests {
+    private func makeCommand(noCache: Bool, cacheDir: String?) -> Generate {
+        var command = Generate()
+        command.noCache = noCache
+        command.packageDepsCacheDir = cacheDir
+        return command
+    }
+
+    @Test
+    func cacheLocationDefaultsToGlobal() {
+        #expect(makeCommand(noCache: false, cacheDir: nil).cacheLocation == .global)
+    }
+
+    @Test
+    func customCacheDirSelectsCustomLocation() {
+        let command = makeCommand(noCache: false, cacheDir: "/tmp/cache")
+        #expect(command.cacheLocation == .custom(path: "/tmp/cache"))
+    }
+
+    @Test
+    func noCacheSelectsDisabledLocation() {
+        #expect(makeCommand(noCache: true, cacheDir: nil).cacheLocation == .disabled)
+    }
+
+    @Test
+    func noCacheAndCustomCacheDirAreMutuallyExclusive() throws {
+        // The conflict check runs before logging is bootstrapped, so calling validate()
+        // here does not initialize the (once-per-process) logging system.
+        var command = makeCommand(noCache: true, cacheDir: "/tmp/cache")
+        #expect(throws: ValidationError.self) {
+            try command.validate()
+        }
+    }
+}

--- a/Tests/LicenseCLITests/IntegrationTests.swift
+++ b/Tests/LicenseCLITests/IntegrationTests.swift
@@ -13,7 +13,6 @@ final class IntegrationTests {
     let cowBoxFixtureURL: URL
     let printLicensesURL: URL
     let binaryOutputURL: URL
-    let cacheDirURL: URL
     let fileManager: FileManager
 
     let outputFileName = "Licenses"
@@ -71,7 +70,6 @@ final class IntegrationTests {
         let fixtureURL = URL(filePath: #filePath).deletingLastPathComponent().appending(component: "Fixtures")
         outputDirURL = fixtureURL.appending(component: "output")
         outputFileURL = outputDirURL.appending(component: outputFileName).appendingPathExtension("swift")
-        cacheDirURL = fixtureURL.appending(component: "cache")
         fileManager = FileManager.default
         tca1FixtureURL = fixtureURL.appending(component: "ComposableArchitecture1")
         tca2FixtureURL = fixtureURL.appending(component: "ComposableArchitecture2")
@@ -81,12 +79,10 @@ final class IntegrationTests {
         binaryOutputURL = outputDirURL.appending(component: "main")
 
         try fileManager.createDirectory(at: outputDirURL, withIntermediateDirectories: true)
-        try fileManager.createDirectory(at: cacheDirURL, withIntermediateDirectories: true)
     }
 
     deinit {
         try? fileManager.removeItem(at: outputDirURL)
-        try? fileManager.removeItem(at: cacheDirURL)
         try? fileManager.removeItem(at: tca1FixtureURL.appending(component: "Package.resolved"))
         try? fileManager.removeItem(at: tca2FixtureURL.appending(component: "Package.resolved"))
         try? fileManager.removeItem(at: nioFixtureURL.appending(component: "Package.resolved"))
@@ -134,7 +130,6 @@ final class IntegrationTests {
                 "https://github.com/apple/app-store-server-library-swift@main",
                 "https://github.com/apple/pkl-swift@main",
             ],
-            packageDepsCacheDirectory: cacheDirURL.path(percentEncoded: false),
             outputDirectoryPath: outputDirURL.path(percentEncoded: false),
             fileName: outputFileName
         )


### PR DESCRIPTION
## Summary

Adds a global, project-shared cache for `--package-deps` clones (pnpm-style), while keeping the existing `--package-deps-cache-dir` option for backward compatibility and adding an opt-out.

By default, clones are cached in `~/Library/Caches/LicenseCLI` (macOS) / `~/.cache/LicenseCLI` (Linux), resolved via `FileManager`'s `.cachesDirectory`. The cache is keyed only by `owner-name@version` — not by project path — so the **same library at the same version is reused across all projects automatically**.

## Cache location options

| Option | Behavior |
|---|---|
| *(none)* | Global, project-shared cache. Subject to automatic TTL pruning. |
| `--package-deps-cache-dir <path>` | Cache in `<path>`, used as-is (no `LicenseCLI` subdir) and **exempt from pruning** — matches the prior behavior of this option. |
| `--no-cache` | Clone into a temporary directory discarded after the run. |

`--package-deps-cache-dir` and `--no-cache` are mutually exclusive (rejected in `validate()`).

## Cache lifecycle (GC)

- **Automatic TTL GC**: on every run, **global-cache** entries unused for more than **30 days** are pruned (tracked via each entry's modification date, touched on every cache hit). A custom cache directory is never pruned automatically.
- **Manual prune**: the `cache-prune` subcommand clears the entire global cache on demand.

## CLI structure

The root command is a dispatcher with two subcommands:

| Command | Purpose |
|---|---|
| `generate` (default) | Generate the license file (the previous behavior) |
| `cache-prune` | Remove all cached package clones from the global cache |

`generate` is the default subcommand, so existing invocations (`licensecli --output-directory ...`) keep working unchanged.

## Notes

- `CacheDirectory` owns the cache location, keying, TTL GC, and prune; `CacheLocation` resolves the CLI options into an optional `CacheDirectory`.
- Tests cover cache keying, path-traversal confinement, custom-path layout, custom-cache GC exemption, and the mutually-exclusive option rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)